### PR TITLE
Align sitemap and robots domain

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -6,4 +6,4 @@ Allow: /
 # Disallow: /cart/
 
 # Sitemap location (replace with your final domain)
-Sitemap: https://www.peterpohlschmidt.com/sitemap.xml
+Sitemap: https://pohlschmidt.de/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <!-- Replace with your final domain -->
-    <loc>https://www.peterpohlschmidt.com/</loc>
+    <loc>https://pohlschmidt.de/</loc>
     <lastmod>2025-06-11</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- use `https://pohlschmidt.de/` across canonical link, robots.txt and sitemap

## Testing
- `npm test` *(fails: ENOENT, no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a5f71bfec832e8bc6c587b445b3d9